### PR TITLE
added gulp and browsersync for auto reload

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,7 @@ exclude:
   - node_modules
   - package.json
   - postcss.config.js
+  - gulpfile.js
 
 
 # http://jekyllrb.com/docs/collections/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,17 @@
+var gulp = require('gulp');
+var shell = require('gulp-shell');
+var browserSync = require('browser-sync').create();
+
+// Task for building blog when something changed:
+gulp.task('build', shell.task(['bundle exec jekyll build --watch']));
+// Or if you don't use bundle:
+// gulp.task('build', shell.task(['jekyll build --watch']));
+
+// Task for serving blog with Browsersync
+gulp.task('serve', function () {
+    browserSync.init({server: {baseDir: '_site/'}});
+    // Reloads page when some of the already built files changed:
+    gulp.watch('_site/**/*.*').on('change', browserSync.reload);
+});
+
+gulp.task('default', ['build', 'serve']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jekyll-starter",
+  "version": "1.0.0",
+  "description": "[Presentation on Google Docs](https://docs.google.com/presentation/d/1XRW5y-Rarne05XJZzksuklwe5FicQVVYrHVduQ015hU/edit?usp=sharing)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wangsongiam/jekyll-starter.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/wangsongiam/jekyll-starter/issues"
+  },
+  "homepage": "https://github.com/wangsongiam/jekyll-starter#readme",
+  "devDependencies": {
+    "browser-sync": "^2.17.5",
+    "gulp": "^3.9.1",
+    "gulp-shell": "^0.5.2",
+    "lodash": "^4.16.6"
+  }
+}


### PR DESCRIPTION
without browser sync, we need to exec `cmd+c` and  `bundle exec Jekyll serve` whenever we had a change, which is inefficient for developing. With `gulp`, `browser sync` and a gulp plugin `gulp-shell`, we can make this much easier. Now, just exec `gulp` in the terminal, every file will be watched. And whenever we have a change, it will be rebuilt and reloaded automatically in the browser.

![screen shot 2016-11-10 at 9 35 13 pm](https://cloud.githubusercontent.com/assets/19645990/20202519/b68bb9be-a78d-11e6-9438-a9e811cbb66b.png)

more info on https://nvbn.github.io/2015/06/19/jekyll-browsersync/
